### PR TITLE
Add a performance repair

### DIFF
--- a/cuda.rkt
+++ b/cuda.rkt
@@ -283,6 +283,9 @@
 
     [else (f x)]))
 
+(define (all-split? x f)
+  (for/all ([x x #:exhaustive]) (all? x f)))
+
 (define (size-of x)
    (cond
     [(vector? x)
@@ -307,8 +310,8 @@
       [(member op (list @+ @-))
        (cond
          [(all? (first args) zero?) 0]
-         [(for/all ([val (second args) #:exhaustive]) (all? val zero?)) 0]
-         [(for/all ([ret ret #:exhaustive]) (all? ret zero?)) 0]
+         [(all-split? (second args) zero?) 0]
+         [(all? ret zero?) 0]
          [else op-cost])]
 
       [(member op (list @modulo))
@@ -318,7 +321,7 @@
       
       [(member op (list @*))
        (cond
-         [(all? (first args) zero?) 0]
+         [(all-split? (first args) zero?) 0]
          [(all? (first args) one?) 0]
          [(all? (first args) minus-one?) 0]
          [(all? (second args) zero?) 0]

--- a/cuda.rkt
+++ b/cuda.rkt
@@ -307,8 +307,8 @@
       [(member op (list @+ @-))
        (cond
          [(all? (first args) zero?) 0]
-         [(all? (second args) zero?) 0]
-         [(all? ret zero?) 0]
+         [(for/all ([val (second args) #:exhaustive]) (all? val zero?)) 0]
+         [(for/all ([ret ret #:exhaustive]) (all? ret zero?)) 0]
          [else op-cost])]
 
       [(member op (list @modulo))
@@ -790,7 +790,8 @@
 
 ;; Accumulator equal
 (define (acc=? x y recursive-equal?)
-  (and (multiset= (accumulator-val x) (accumulator-val y))
+  (and (for/all ([val (accumulator-val y) #:exhaustive])
+         (multiset= (accumulator-val x) val))
        (equal? (accumulator-oplist x) (accumulator-oplist y))
        (equal? (accumulator-opfinal x) (accumulator-opfinal y))))
 


### PR DESCRIPTION
This PR adds a performance repair discovered by our tool. It reduces the running time of:

- `ex2-conv1d.rkt` from 10868 ms to 5885 ms
- `ex2-stencil2d.rkt` from 478718 ms to 473972 ms
- `ex4-aos-sum.rkt` from 6648 ms to 5851 ms

(Actually the running time of `ex2-stencil.rkt` is also reduced, though only by a tiny bit).

It did not negatively impact any other files. 

This should not affect the correctness of the program. From a quick glance, the output after applying the repair looks the same.